### PR TITLE
fix(island): refresh dynamic lyric width

### DIFF
--- a/app/src/main/java/com/lidesheng/hyperlyric/root/island/presentation/IslandNativeRefreshCoordinator.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/root/island/presentation/IslandNativeRefreshCoordinator.kt
@@ -32,10 +32,16 @@ internal object IslandNativeRefreshCoordinator {
     }
 
     fun request(
-        onComplete: (ViewGroup) -> Unit
+        onComplete: (ViewGroup) -> Unit,
+        targetRoot: ViewGroup? = null,
+        onUnavailable: (() -> Unit)? = null
     ) {
         runOnMain {
-            pendingRequest = RefreshRequest(onComplete)
+            pendingRequest = RefreshRequest(
+                onComplete = onComplete,
+                targetRoot = targetRoot,
+                onUnavailable = onUnavailable
+            )
             mainHandler.removeCallbacks(requestRunnable)
             mainHandler.postDelayed(requestRunnable, REQUEST_DEBOUNCE_MS)
         }
@@ -67,32 +73,45 @@ internal object IslandNativeRefreshCoordinator {
 
         val packageName = LyriconDataBridge.currentLyricPackageName
             ?.takeIf { it.isNotEmpty() }
-            ?: return
+            ?: run {
+                notifyUnavailable(request)
+                return
+            }
 
         var accepted = false
-        IslandPresentationCoordinator.snapshotAttachedHosts(packageName).forEach { token ->
-            if (!isEligibleHost(token)) return@forEach
+        IslandPresentationCoordinator.snapshotAttachedHosts(packageName)
+            .filter { token -> request.targetRoot == null || token.root === request.targetRoot }
+            .forEach { token ->
+                if (!isEligibleHost(token)) return@forEach
 
-            val target = resolveTarget(token) ?: return@forEach
-            val existing = activeRefreshes[token.root]
-            if (existing != null) {
-                existing.request = request
-                accepted = true
-                return@forEach
+                val target = resolveTarget(token) ?: return@forEach
+                val existing = activeRefreshes[token.root]
+                if (existing != null) {
+                    existing.request = request
+                    accepted = true
+                    return@forEach
+                }
+
+                val active = ActiveRefresh(token, request)
+                activeRefreshes[token.root] = active
+                if (invokeNativeUpdate(target, active)) {
+                    accepted = true
+                } else if (activeRefreshes[token.root] === active) {
+                    activeRefreshes.remove(token.root)
+                }
             }
 
-            val active = ActiveRefresh(token, request)
-            activeRefreshes[token.root] = active
-            if (invokeNativeUpdate(target, active)) {
-                accepted = true
-            } else if (activeRefreshes[token.root] === active) {
-                activeRefreshes.remove(token.root)
-            }
-        }
-
-        if (!accepted && activeRefreshes.isEmpty()) {
+        if (!accepted) {
             HookLogger.d(TAG, "未找到可执行小米原生超级岛刷新的当前媒体岛")
+            notifyUnavailable(request)
         }
+    }
+
+    private fun notifyUnavailable(request: RefreshRequest) {
+        runCatching { request.onUnavailable?.invoke() }
+            .onFailure { error ->
+                HookLogger.e(TAG, "小米原生超级岛刷新回退失败", error)
+            }
     }
 
     private fun isEligibleHost(token: IslandViewRegistry.HostToken): Boolean {
@@ -132,7 +151,16 @@ internal object IslandNativeRefreshCoordinator {
         } as? Number)?.toFloat() ?: return null
         val updateMethod = windowView.javaClass.methods.firstOrNull(::isNativeUpdateMethod)
             ?: run {
-                HookLogger.w(TAG, "小米超级岛原生刷新接口不可用: target=updateDynamicIslandView")
+                val candidates = windowView.javaClass.methods
+                    .filter { it.name.contains("DynamicIsland", ignoreCase = true) }
+                    .joinToString(separator = ";") { method ->
+                        "${method.name}(${method.parameterTypes.joinToString(",") { it.name }})"
+                    }
+                HookLogger.w(
+                    TAG,
+                    "小米超级岛原生刷新接口不可用: target=updateDynamicIslandView, " +
+                            "window=${windowView.javaClass.name}, candidates=$candidates"
+                )
                 return null
             }
 
@@ -148,13 +176,14 @@ internal object IslandNativeRefreshCoordinator {
 
     private fun invokeNativeUpdate(target: NativeTarget, active: ActiveRefresh): Boolean {
         return runCatching {
-            target.updateMethod.invoke(
-                target.windowView,
-                target.data,
-                false,
-                target.maxWidth,
-                false
-            )
+            val arguments = when (target.updateMethod.parameterTypes.size) {
+                // HyperOS 3 removed the trailing transition flag from this API.
+                3 -> arrayOf(target.data, false, target.maxWidth)
+                // Keep compatibility with older HyperOS releases.
+                4 -> arrayOf(target.data, false, target.maxWidth, false)
+                else -> error("unexpected updateDynamicIslandView signature")
+            }
+            target.updateMethod.invoke(target.windowView, *arguments)
             active.settleRunnable = Runnable {
                 activeRefreshes[target.root]?.let { current ->
                     if (current === active) complete(target.root, current, "settle_timeout")
@@ -168,7 +197,8 @@ internal object IslandNativeRefreshCoordinator {
             HookLogger.d(
                 TAG,
                 "已请求小米原生超级岛刷新: root=${System.identityHashCode(target.root)}, " +
-                        "keyHash=${target.key.hashCode()}, maxWidth=${target.maxWidth}"
+                        "keyHash=${target.key.hashCode()}, maxWidth=${target.maxWidth}, " +
+                        "parameterCount=${target.updateMethod.parameterTypes.size}"
             )
             true
         }.getOrElse { error ->
@@ -205,11 +235,14 @@ internal object IslandNativeRefreshCoordinator {
 
     private fun isNativeUpdateMethod(method: Method): Boolean {
         val types = method.parameterTypes
-        return method.name == "updateDynamicIslandView" &&
-                types.size == 4 &&
-                types[1] == Boolean::class.javaPrimitiveType &&
-                types[2] == Float::class.javaPrimitiveType &&
-                types[3] == Boolean::class.javaPrimitiveType
+        if (method.name != "updateDynamicIslandView" ||
+            (types.size != 3 && types.size != 4) ||
+            types[1] != Boolean::class.javaPrimitiveType ||
+            types[2] != Float::class.javaPrimitiveType
+        ) {
+            return false
+        }
+        return types.size == 3 || types[3] == Boolean::class.javaPrimitiveType
     }
 
     private fun runOnMain(block: () -> Unit) {
@@ -221,7 +254,9 @@ internal object IslandNativeRefreshCoordinator {
     }
 
     private data class RefreshRequest(
-        val onComplete: (ViewGroup) -> Unit
+        val onComplete: (ViewGroup) -> Unit,
+        val targetRoot: ViewGroup?,
+        val onUnavailable: (() -> Unit)?
     )
 
     private class ActiveRefresh(

--- a/app/src/main/java/com/lidesheng/hyperlyric/root/island/sizing/IslandDynamicWidthCoordinator.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/root/island/sizing/IslandDynamicWidthCoordinator.kt
@@ -10,6 +10,7 @@ import com.lidesheng.hyperlyric.root.island.config.IslandSlotRuntimeConfig
 import com.lidesheng.hyperlyric.root.island.host.IslandHostFacade
 import com.lidesheng.hyperlyric.root.island.host.IslandProbeUtils
 import com.lidesheng.hyperlyric.root.island.host.IslandViewRegistry
+import com.lidesheng.hyperlyric.root.island.presentation.IslandNativeRefreshCoordinator
 import com.lidesheng.hyperlyric.root.island.presentation.IslandPresentationCoordinator
 import com.lidesheng.hyperlyric.root.island.view.MaxWidthFrameLayout
 import java.util.WeakHashMap
@@ -246,10 +247,22 @@ internal object IslandDynamicWidthCoordinator {
         ) ?: return false
         val wrapper = rootView.findViewWithTag<View>("${viewTag}_WRAPPER")
             as? MaxWidthFrameLayout ?: return false
-        if (wrapper.maxWidthPx == targetWidthPx) return false
+        val configuredMaxWidthPx = config.geometry.widthPx(rootView, parentName) ?: return false
+        val layoutParams = wrapper.layoutParams
+        val widthChanged = wrapper.desiredWidthPx != targetWidthPx ||
+                wrapper.maxWidthPx != configuredMaxWidthPx ||
+                (layoutParams != null && layoutParams.width != targetWidthPx)
+        if (!widthChanged) return false
 
-        wrapper.maxWidthPx = targetWidthPx
+        wrapper.maxWidthPx = configuredMaxWidthPx
+        wrapper.desiredWidthPx = targetWidthPx
+        if (layoutParams != null && layoutParams.width != targetWidthPx) {
+            layoutParams.width = targetWidthPx
+            wrapper.layoutParams = layoutParams
+        }
         wrapper.requestLayout()
+        wrapper.parent?.requestLayout()
+        rootView.requestLayout()
         return true
     }
 
@@ -269,7 +282,25 @@ internal object IslandDynamicWidthCoordinator {
                 if (IslandViewRegistry.tokenFor(rootView) != null &&
                     IslandPresentationCoordinator.isPlaybackActive()
                 ) {
-                    IslandHostFacade.triggerSystemRelayout(rootView)
+                    IslandNativeRefreshCoordinator.request(
+                        onComplete = { refreshedRoot ->
+                            // Xiaomi rebuilds the module hierarchy during the native update.
+                            // Re-read the lyric width after that callback in case the rebuild
+                            // replaced the injected wrapper or applied a newer lyric line.
+                            requestRefresh(refreshedRoot)
+                        },
+                        targetRoot = rootView,
+                        onUnavailable = {
+                            val token = IslandViewRegistry.tokenFor(rootView)
+                            if (token != null &&
+                                IslandPresentationCoordinator.isCurrentHost(token) &&
+                                !IslandPresentationCoordinator.isHostFrozenForFakeTransition(token) &&
+                                IslandPresentationCoordinator.isPlaybackActive()
+                            ) {
+                                IslandHostFacade.triggerSystemRelayout(rootView)
+                            }
+                        }
+                    )
                 }
             } finally {
                 synchronized(relayoutPending) {

--- a/app/src/main/java/com/lidesheng/hyperlyric/root/island/structure/IslandSlotStructureInjector.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/root/island/structure/IslandSlotStructureInjector.kt
@@ -386,21 +386,29 @@ internal object IslandSlotStructureInjector {
             wrapper.minimumWidth = 0
             changed = true
         }
-        // Dynamic width is refined from the current lyric line after the wrapper is attached.
-        // Keep that measured value during a lifecycle re-ensure (especially pause/keep),
-        // otherwise the paused path skips the width refresh and leaves the wrapper at the
-        // configured maximum until playback resumes.
-        val targetMaxWidthPx = if (config.geometry.isDynamicWidth && wrapper.maxWidthPx > 0) {
-            minOf(wrapper.maxWidthPx, widthPx)
+        // Keep the configured cap separate from the current dynamic target. The target is
+        // refreshed from the lyric line after the wrapper is attached and must survive lifecycle
+        // re-ensure paths (especially pause/keep), where content refresh can be skipped.
+        val targetMaxWidthPx = widthPx
+        val targetDesiredWidthPx = if (config.geometry.isDynamicWidth) {
+            wrapper.desiredWidthPx.takeIf { it > 0 }?.coerceAtMost(widthPx) ?: widthPx
         } else {
-            widthPx
+            -1
         }
         if (wrapper.maxWidthPx != targetMaxWidthPx) {
             wrapper.maxWidthPx = targetMaxWidthPx
             changed = true
         }
+        if (wrapper.desiredWidthPx != targetDesiredWidthPx) {
+            wrapper.desiredWidthPx = targetDesiredWidthPx
+            changed = true
+        }
         val layoutParams = wrapper.layoutParams
-        val expectedWidth = wrapperLayoutWidth(config)
+        val expectedWidth = if (config.geometry.isDynamicWidth && wrapper.desiredWidthPx > 0) {
+            wrapper.desiredWidthPx
+        } else {
+            wrapperLayoutWidth(config)
+        }
         if (layoutParams != null && (layoutParams.width != expectedWidth || layoutParams.height != FrameLayout.LayoutParams.MATCH_PARENT)) {
             layoutParams.width = expectedWidth
             layoutParams.height = FrameLayout.LayoutParams.MATCH_PARENT
@@ -480,7 +488,7 @@ internal object IslandSlotStructureInjector {
     }
 
     private fun wrapperLayoutWidth(config: IslandSlotRuntimeConfig): Int {
-        return if (config.isSplitMode) {
+        return if (config.geometry.isDynamicWidth || config.isSplitMode) {
             FrameLayout.LayoutParams.WRAP_CONTENT
         } else {
             FrameLayout.LayoutParams.MATCH_PARENT

--- a/app/src/main/java/com/lidesheng/hyperlyric/root/island/view/MaxWidthFrameLayout.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/root/island/view/MaxWidthFrameLayout.kt
@@ -11,8 +11,16 @@ class MaxWidthFrameLayout(context: Context) : FrameLayout(context) {
 
     /**
      * 最大宽度（像素）。设置为 -1（默认）则不限制。
+     *
+     * This is deliberately kept separate from [desiredWidthPx]. A dynamic lyric update changes
+     * the desired width; it must not turn the current width into the next measurement ceiling.
      */
     var maxWidthPx: Int = -1
+
+    /**
+     * Requested content width（像素）。设置为 -1（默认）时回退到 [maxWidthPx] 或父级规格。
+     */
+    var desiredWidthPx: Int = -1
 
     /**
      * Used only by injected Super Island test blocks.
@@ -28,15 +36,36 @@ class MaxWidthFrameLayout(context: Context) : FrameLayout(context) {
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val givenWidth = MeasureSpec.getSize(widthMeasureSpec)
-        val newWidth =
-            if (maxWidthPx > 0 && (givenWidth == 0 || givenWidth > maxWidthPx)) maxWidthPx else givenWidth
+        val requestedWidth = when {
+            desiredWidthPx > 0 -> desiredWidthPx
+            maxWidthPx > 0 -> maxWidthPx
+            else -> -1
+        }
+
+        if (requestedWidth <= 0) {
+            // Preserve normal FrameLayout measurement when no explicit width is configured.
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+            return
+        }
+
+        val widthLimit = maxWidthPx.takeIf { it > 0 } ?: requestedWidth
+        val boundedWidth = requestedWidth.coerceAtMost(widthLimit)
+        val parentMode = MeasureSpec.getMode(widthMeasureSpec)
+        val parentSize = MeasureSpec.getSize(widthMeasureSpec)
+        val resolvedWidth = when (parentMode) {
+            MeasureSpec.UNSPECIFIED -> boundedWidth
+            MeasureSpec.AT_MOST,
+            MeasureSpec.EXACTLY -> boundedWidth.coerceAtMost(parentSize)
+            else -> boundedWidth
+        }
         super.onMeasure(
-            MeasureSpec.makeMeasureSpec(newWidth, MeasureSpec.AT_MOST),
+            MeasureSpec.makeMeasureSpec(resolvedWidth, MeasureSpec.EXACTLY),
             heightMeasureSpec
         )
-        if (maxWidthPx > 0 && measuredWidth > maxWidthPx) {
-            setMeasuredDimension(maxWidthPx, measuredHeight)
+
+        val cappedMeasuredWidth = measuredWidth.coerceAtMost(boundedWidth)
+        if (cappedMeasuredWidth != measuredWidth) {
+            setMeasuredDimension(cappedMeasuredWidth, measuredHeight)
         }
     }
 }


### PR DESCRIPTION
Keep requested lyric width separate from the configured cap and preserve the cap under EXACTLY measure specs. Target Xiaomi native refreshes to the active island root and fall back to the existing SystemUI relayout path when the native API is unavailable.