### PR TITLE
feat(content-layout): 新增隐藏别名

### DIFF
--- a/app/src/main/java/com/lidesheng/hyperlyric/common/MusicInfoLayoutPolicy.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/common/MusicInfoLayoutPolicy.kt
@@ -59,6 +59,29 @@ object MusicInfoLayoutPolicy {
             ?: RootConstants.DEFAULT_HOOK_ISLAND_MUSIC_INFO_SEPARATOR
     }
 
+    private val titleAliasPattern =
+        Regex("""（[^（）]*）|\([^()]*\)|【[^【】]*】|\[[^\[\]]*\]""")
+    private val collapsedSpaces = Regex("\\s{2,}")
+
+    fun readHideTitleAlias(prefs: SharedPreferences): Boolean {
+        return prefs.getBoolean(
+            RootConstants.KEY_HOOK_ISLAND_MUSIC_INFO_HIDE_TITLE_ALIAS,
+            RootConstants.DEFAULT_HOOK_ISLAND_MUSIC_INFO_HIDE_TITLE_ALIAS
+        )
+    }
+
+    /**
+     * 移除歌名中成对括号（全角 （）【】 与半角 ()[]）内的别名，用于显示。
+     * 移除后折叠连续空格并去除首尾空白；若结果为空则回退原标题。
+     */
+    fun stripTitleAlias(title: String): String {
+        val stripped = title
+            .replace(titleAliasPattern, "")
+            .replace(collapsedSpaces, " ")
+            .trim()
+        return stripped.ifBlank { title }
+    }
+
     fun separatorValue(separator: String): String = when (separator) {
         SEPARATOR_PLUS -> " + "
         SEPARATOR_SPACE -> " "

--- a/app/src/main/java/com/lidesheng/hyperlyric/common/RootConstants.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/common/RootConstants.kt
@@ -19,6 +19,8 @@ object RootConstants {
         "key_hook_island_music_info_second_line"
     const val KEY_HOOK_ISLAND_MUSIC_INFO_SEPARATOR =
         "key_hook_island_music_info_separator"
+    const val KEY_HOOK_ISLAND_MUSIC_INFO_HIDE_TITLE_ALIAS =
+        "key_hook_island_music_info_hide_title_alias"
     const val KEY_HOOK_ISLAND_LEFT_PADDING_LEFT = "key_hook_island_left_padding_left"
     const val KEY_HOOK_ISLAND_LEFT_PADDING_RIGHT = "key_hook_island_left_padding_right"
     const val KEY_HOOK_ISLAND_RIGHT_PADDING_LEFT = "key_hook_island_right_padding_left"
@@ -243,6 +245,7 @@ object RootConstants {
     const val DEFAULT_HOOK_ISLAND_MUSIC_INFO_FIRST_LINE = "title"
     const val DEFAULT_HOOK_ISLAND_MUSIC_INFO_SECOND_LINE = "artist"
     const val DEFAULT_HOOK_ISLAND_MUSIC_INFO_SEPARATOR = "hyphen"
+    const val DEFAULT_HOOK_ISLAND_MUSIC_INFO_HIDE_TITLE_ALIAS = false
     const val DEFAULT_HOOK_ISLAND_LEFT_PADDING_LEFT = 2
     const val DEFAULT_HOOK_ISLAND_LEFT_PADDING_RIGHT = 0
     const val DEFAULT_HOOK_ISLAND_RIGHT_PADDING_LEFT = 0

--- a/app/src/main/java/com/lidesheng/hyperlyric/root/island/content/IslandMetadataContentAssembler.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/root/island/content/IslandMetadataContentAssembler.kt
@@ -61,8 +61,7 @@ internal object IslandMetadataContentAssembler {
         playbackPosition: Long = LyriconDataBridge.currentPosition,
         playbackDuration: Long = mediaInfo.duration
     ): ConfiguredMusicInfoLines {
-        val songName = mediaInfo.title.takeIf { it.isNotBlank() }
-            ?: LyriconDataBridge.currentSongName.orEmpty()
+        val songName = resolveSongName(prefs, mediaInfo)
         val durationText = mediaInfo.duration.takeIf { it > 0L }
             ?.let { formatMediaTime(it, it) }
             .orEmpty()
@@ -107,8 +106,7 @@ internal object IslandMetadataContentAssembler {
         playbackPosition: Long = LyriconDataBridge.currentPosition,
         playbackDuration: Long = mediaInfo.duration
     ): Boolean {
-        val songName = mediaInfo.title.takeIf { it.isNotBlank() }
-            ?: LyriconDataBridge.currentSongName.orEmpty()
+        val songName = resolveSongName(prefs, mediaInfo)
         val artistName = mediaInfo.artist
         val albumName = mediaInfo.album
         val durationText = mediaInfo.duration.takeIf { it > 0L }
@@ -225,6 +223,23 @@ internal object IslandMetadataContentAssembler {
                     "marquee=${config.metadataMarqueeEnabled}, force=$force"
         }
         return true
+    }
+
+    /**
+     * 解析用于展示的歌名：优先取媒体元数据标题，空白时回退歌词桥歌名；
+     * 开启“隐藏歌名别名”后移除成对括号内的别名。
+     */
+    private fun resolveSongName(
+        prefs: SharedPreferences,
+        mediaInfo: MediaMetadataHelper.MediaInfo
+    ): String {
+        val raw = mediaInfo.title.takeIf { it.isNotBlank() }
+            ?: LyriconDataBridge.currentSongName.orEmpty()
+        return if (MusicInfoLayoutPolicy.readHideTitleAlias(prefs)) {
+            MusicInfoLayoutPolicy.stripTitleAlias(raw)
+        } else {
+            raw
+        }
     }
 
     /**

--- a/app/src/main/java/com/lidesheng/hyperlyric/ui/page/hooksettings/lyrics/contentlayout/ContentLayoutPage.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/ui/page/hooksettings/lyrics/contentlayout/ContentLayoutPage.kt
@@ -84,6 +84,14 @@ fun ContentLayoutPage() {
             )
         )
     }
+    var hideTitleAlias by remember(prefs) {
+        mutableStateOf(
+            prefs.getBoolean(
+                RootConstants.KEY_HOOK_ISLAND_MUSIC_INFO_HIDE_TITLE_ALIAS,
+                RootConstants.DEFAULT_HOOK_ISLAND_MUSIC_INFO_HIDE_TITLE_ALIAS
+            )
+        )
+    }
     var editingRow by remember { mutableStateOf<Int?>(null) }
 
     val currentEditingRow = editingRow
@@ -170,6 +178,14 @@ fun ContentLayoutPage() {
             onPlaceholderFormatChange = {
                 placeholderFormat = it
                 PrefsBridge.putInt(RootConstants.KEY_HOOK_PLACEHOLDER_FORMAT, it)
+            },
+            hideTitleAlias = hideTitleAlias,
+            onHideTitleAliasChange = {
+                hideTitleAlias = it
+                PrefsBridge.putBoolean(
+                    RootConstants.KEY_HOOK_ISLAND_MUSIC_INFO_HIDE_TITLE_ALIAS,
+                    it
+                )
             }
         )
     }

--- a/app/src/main/java/com/lidesheng/hyperlyric/ui/page/hooksettings/lyrics/contentlayout/ContentLayoutSections.kt
+++ b/app/src/main/java/com/lidesheng/hyperlyric/ui/page/hooksettings/lyrics/contentlayout/ContentLayoutSections.kt
@@ -102,7 +102,9 @@ internal fun LazyListScope.contentLayoutSections(
     rightLyric: Boolean,
     onRightLyricChange: (Boolean) -> Unit,
     placeholderFormat: Int,
-    onPlaceholderFormatChange: (Int) -> Unit
+    onPlaceholderFormatChange: (Int) -> Unit,
+    hideTitleAlias: Boolean,
+    onHideTitleAliasChange: (Boolean) -> Unit
 ) {
     item(key = "music_info_title") {
         SmallTitle(text = stringResource(id = R.string.title_content_layout_music_info))
@@ -142,6 +144,12 @@ internal fun LazyListScope.contentLayoutSections(
                     title = stringResource(id = R.string.title_center_music_info),
                     checked = centerMusicInfo,
                     onCheckedChange = onCenterMusicInfoChange
+                )
+                SwitchPreference(
+                    title = stringResource(id = R.string.title_hide_title_alias),
+                    summary = stringResource(id = R.string.summary_hide_title_alias),
+                    checked = hideTitleAlias,
+                    onCheckedChange = onHideTitleAliasChange
                 )
             }
         }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -430,6 +430,8 @@
   <string name="title_content_layout_music_info">معلومات الموسيقى</string>
   <string name="title_content_layout_lyric">الكلمات</string>
   <string name="title_center_music_info">عرض في المنتصف</string>
+  <string name="title_hide_title_alias">إخفاء الاسم البديل للأغنية</string>
+  <string name="summary_hide_title_alias">إزالة الأسماء البديلة بين الأقواس من اسم الأغنية</string>
   <string name="title_content_layout_first_line">السطر الأول</string>
   <string name="title_content_layout_second_line">السطر الثاني</string>
   <string name="summary_content_layout_select_fields">اختار حقول معلومات الموسيقى اللي عايز تعرضها</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -426,6 +426,8 @@
     <string name="title_content_layout_music_info">Music information</string>
     <string name="title_content_layout_lyric">Lyrics</string>
     <string name="title_center_music_info">Center display</string>
+    <string name="title_hide_title_alias">Hide title alias</string>
+    <string name="summary_hide_title_alias">Remove bracketed aliases from the song title, e.g. show only the main name</string>
     <string name="title_content_layout_first_line">First line</string>
     <string name="title_content_layout_second_line">Second line</string>
     <string name="summary_content_layout_select_fields">Choose the music information fields to display</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,6 +451,8 @@
     <string name="title_content_layout_music_info">音乐信息</string>
     <string name="title_content_layout_lyric">歌词</string>
     <string name="title_center_music_info">居中显示</string>
+    <string name="title_hide_title_alias">隐藏歌名别名</string>
+    <string name="summary_hide_title_alias">移除歌名中括号内的别名”</string>
     <string name="title_content_layout_first_line">第一行</string>
     <string name="title_content_layout_second_line">第二行</string>
     <string name="summary_content_layout_select_fields">选择要显示的音乐信息字段</string>

--- a/app/src/test/java/com/lidesheng/hyperlyric/common/MusicInfoLayoutPolicyTest.kt
+++ b/app/src/test/java/com/lidesheng/hyperlyric/common/MusicInfoLayoutPolicyTest.kt
@@ -1,0 +1,88 @@
+package com.lidesheng.hyperlyric.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MusicInfoLayoutPolicyTest {
+
+    @Test
+    fun fullWidthParenthesesAliasRemoved() {
+        // 全角括号内的别名应被移除
+        assertEquals(
+            "痴人说梦",
+            MusicInfoLayoutPolicy.stripTitleAlias("痴人说梦（《崩坏：星穹铁道》火花角色PV曲）")
+        )
+    }
+
+    @Test
+    fun halfWidthParenthesesRemovedAndTrimmed() {
+        // 半角括号内容被移除并去除残留空格
+        assertEquals(
+            "Song Name",
+            MusicInfoLayoutPolicy.stripTitleAlias("Song Name (Live)")
+        )
+    }
+
+    @Test
+    fun squareBracketsContentRemoved() {
+        // 方括号内容被移除
+        assertEquals(
+            "Name",
+            MusicInfoLayoutPolicy.stripTitleAlias("Name [Remix]")
+        )
+    }
+
+    @Test
+    fun fullWidthSquareBracketsContentRemoved() {
+        // 全角方头括号内容被移除
+        assertEquals(
+            "歌名",
+            MusicInfoLayoutPolicy.stripTitleAlias("歌名【角色PV】")
+        )
+    }
+
+    @Test
+    fun titleWithoutBracketsUnchanged() {
+        // 无括号标题保持原样
+        assertEquals(
+            "普通歌名",
+            MusicInfoLayoutPolicy.stripTitleAlias("普通歌名")
+        )
+    }
+
+    @Test
+    fun fallbackToOriginalWhenAllRemoved() {
+        // 整段括号移除后为空时回退原标题
+        assertEquals(
+            "（纯音乐）",
+            MusicInfoLayoutPolicy.stripTitleAlias("（纯音乐）")
+        )
+    }
+
+    @Test
+    fun multipleBracketGroupsAllRemoved() {
+        // 多段括号全部移除
+        assertEquals(
+            "AB",
+            MusicInfoLayoutPolicy.stripTitleAlias("A（x）B（y）")
+        )
+    }
+
+    @Test
+    fun consecutiveSpacesCollapsed() {
+        // 多个连续空格折叠为单个空格
+        assertEquals(
+            "A B",
+            MusicInfoLayoutPolicy.stripTitleAlias("A (x) B")
+        )
+    }
+
+    @Test
+    fun unpairedBracketsKeptAsIs() {
+        // 不成对括号保持原样
+        assertEquals(
+            "歌名（未闭合",
+            MusicInfoLayoutPolicy.stripTitleAlias("歌名（未闭合")
+        )
+    }
+}


### PR DESCRIPTION
## 新增功能：隐藏歌名别名

### 背景

部分歌曲标题带有括号别名（如《痴人说梦》（《崩坏：星穹铁道》火花角色PV曲）），超级岛显示空间有限，冗长标题影响观感。

### 改动说明

新增设置项 **隐藏歌名别名**（默认关闭），位于 **小米超级岛歌词 → 内容布局 → 音乐信息**。

开启后，音乐信息"标题"字段在渲染时移除成对括号及其内部内容，支持全角 （）【】 与半角 () []；移除后折叠连续空格并去除首尾空白；若移除后为空则回退原标题，避免整段标题被清空。

同时作用于超级岛媒体信息显示与长按拖拽分享标题，两者共用同一解析逻辑，保持一致。设置关闭时行为与现状完全一致。

### 涉及文件

- `RootConstants.kt`：新增 pref key `key_hook_island_music_info_hide_title_alias` 及默认值
- `MusicInfoLayoutPolicy.kt`：新增 `readHideTitleAlias()` 与纯函数 `stripTitleAlias()`
- `IslandMetadataContentAssembler.kt`：两处重复歌名解析收敛为 `resolveSongName()`，按设置应用清理
- `ContentLayoutSections.kt` / `ContentLayoutPage.kt`：设置项 UI 与读写
- `values` / `values-en` / `values-ar` strings.xml：三语言文案
- `MusicInfoLayoutPolicyTest.kt`：新增 9 个纯函数单测

### 测试

- [x] `MusicInfoLayoutPolicyTest` 9 个用例全部通过（全角/半角/方括号/无括号/整段括号回退/多段括号/空格折叠/不成对括号）
- [x] `:app:compileDebugKotlin` 编译通过
- [x] 实机验证：《痴人说梦》（《崩坏：星穹铁道》火花角色PV曲）开启开关后岛上仅显示"痴人说梦"，关闭后 ~~（需要切歌）~~ 恢复原标题

> 图中设置项描述中 逗号及后面的内容 已在提交中移除；
代码由 GLM 5.3 生成，已在实机测试通过。

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dbe4e2ad-b24f-4c2f-8bbf-ab3afa365dc3" />